### PR TITLE
put test dfs in global env, hackishly closes #16

### DIFF
--- a/tests/testthat/test-default_parameter_assignment.R
+++ b/tests/testthat/test-default_parameter_assignment.R
@@ -17,7 +17,9 @@ make_data <- function(nrow = 500) {
       ReportedCycleLength = sample(14:28, nrow, TRUE)
     )
 }
-test_df = make_data()
+# HACK: code executed in the multiverse only has access to the global environment, so need to put
+# variables into that environment for testing purposes. TODO: come up with better solution
+test_df <<- make_data()
 
 M = multiverse()
 inside(M, {

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -19,8 +19,9 @@ make_data <- function(nrow = 500) {
       ReportedCycleLength = sample(14:28, nrow, TRUE)
     )
 }
-
-test_df = make_data()
+# HACK: code executed in the multiverse only has access to the global environment, so need to put
+# variables into that environment for testing purposes. TODO: come up with better solution
+test_df <<- make_data()
 
 M = multiverse()
 inside(M, {

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -42,13 +42,13 @@ inside(M, {
       CycleDay = ifelse(CycleDay > 1 & CycleDay < 28, CycleDay, ifelse(CycleDay < 1, 1, 28))
     ) %>%
     dplyr::filter( branch(cycle_length, 
-                   "cl_option1" ~ TRUE,
-                   "cl_option2" ~ ComputedCycleLength > 25 & ComputedCycleLength < 35,
-                   "cl_option3" ~ ReportedCycleLength > 25 & ReportedCycleLength < 35
+                          "cl_option1" ~ TRUE,
+                          "cl_option2" ~ ComputedCycleLength > 25 & ComputedCycleLength < 35,
+                          "cl_option3" ~ ReportedCycleLength > 25 & ReportedCycleLength < 35
     )) %>%
     dplyr::filter( branch(certainty,
-                   "cer_option1" ~ TRUE,
-                   "cer_option2" ~ Sure1 > 6 | Sure2 > 6
+                          "cer_option1" ~ TRUE,
+                          "cer_option2" ~ Sure1 > 6 | Sure2 > 6
     )) %>%
     mutate( Fertility = branch( fertile,
                                 "fer_option1" ~ factor( ifelse(CycleDay >= 7 & CycleDay <= 14, "high", ifelse(CycleDay >= 17 & CycleDay <= 25, "low", "medium")) ),
@@ -58,19 +58,53 @@ inside(M, {
     ))
 })
 
-test_that("given parameter assignment, an expression with branch is converted into proper R code for execution", {
+# get_option_index_from_branch ----------------------------------
+
+test_that("can identify the correct option index from a branch", {
   an_expr.1 = expr(
-      branch(menstrual_calculation, 
-                      "mc_option1" ~ StartDateofLastPeriod + ComputedCycleLength,
-                      "mc_option2" ~ StartDateofLastPeriod + ReportedCycleLength,
-                      "mc_option3" ~ StartDateNext)
-  )
-  
-  an_expr.2 = expr( branch(cycle_length, 
-           "cl_option1" ~ TRUE,
-           "cl_option2" ~ ComputedCycleLength > 25 & ComputedCycleLength < 35,
+    branch(values, 
+           "zero" ~ 0,
+           "three" ~ 3,
+           "null" ~ NULL,
+           "y + 5" ~ y + 5
+    ))
+  an_expr.2 = expr(
+    branch(cycle_length, 
+           "no_filter" ~ TRUE,
+           "25" ~ ComputedCycleLength > 25 & ComputedCycleLength < 35,
            "cl_option3" ~ ReportedCycleLength > 25 & ReportedCycleLength < 35
     ))
+  
+  parameter_values.1 = an_expr.1[-1:-2]
+  parameter_values.2 = an_expr.2[-1:-2]
+  
+  option_name.1 = "mc_option3"
+  option_name.2 = "cl_option2"
+  
+  lgl.1 = map(parameter_values.1, ~ get_option_index_from_branch(.x, option_name.1)) %>% flatten_lgl()
+  lgl.2 = map(parameter_values.2, ~ get_option_index_from_branch(.x, option_name.2)) %>% flatten_lgl()
+  
+  lgl.1.ref = c(FALSE, FALSE, TRUE)
+  lgl.2.ref = c(FALSE, TRUE, FALSE)
+  
+  expect_equal(lgl.1, lgl.1.ref)
+  expect_equal(lgl.2, lgl.2.ref)
+})
+
+# compute_branch ----------------------------------
+
+test_that("given parameter assignment, an expression with branch is converted into proper R code for execution", {
+  an_expr.1 = expr(
+    branch(menstrual_calculation, 
+           "mc_option1" ~ StartDateofLastPeriod + ComputedCycleLength,
+           "mc_option2" ~ StartDateofLastPeriod + ReportedCycleLength,
+           "mc_option3" ~ StartDateNext)
+  )
+  an_expr.2 = expr( branch(cycle_length, 
+                           "cl_option1" ~ TRUE,
+                           "cl_option2" ~ ComputedCycleLength > 25 & ComputedCycleLength < 35,
+                           "cl_option3" ~ ReportedCycleLength > 25 & ReportedCycleLength < 35
+  ))
   
   .assgn_list = list(
     menstrual_calculation = "mc_option1", 
@@ -82,13 +116,13 @@ test_that("given parameter assignment, an expression with branch is converted in
   
   .code.1 = compute_branch( an_expr.1, .assgn_list )
   .code.2 = compute_branch( an_expr.2, .assgn_list )
-  
   .code_ref.1 = expr(StartDateofLastPeriod + ComputedCycleLength)
   .code_ref.2 = expr(ReportedCycleLength > 25 & ReportedCycleLength < 35)
-  
   expect_equal(.code.1, .code_ref.1)
   expect_equal(.code.2, .code_ref.2)
 })
+
+# get_code ----------------------------------
 
 test_that("throws error if multiverse object passed is not R6", {
   param_assgn = 2
@@ -129,6 +163,8 @@ test_that("syntax tree with branches is correctly returned when no parameter is 
   
   expect_equal(f_rhs(u.expr), f_rhs(u.expr.ref))
 })
+
+# get_parameter_code ----------------------------------
 
 test_that("syntax tree with branches is correctly returned when a parameter is assigned", {
   param.assgn <- list(

--- a/tests/testthat/test-multiverse.R
+++ b/tests/testthat/test-multiverse.R
@@ -53,7 +53,7 @@ make_data <- function(nrow = 500) {
     )
 }
 
-test_df = make_data()
+test_df <<- make_data()
 
 inside(M.2, {
   df <- test_df %>%


### PR DESCRIPTION
`testthat` doesn't execute code in the global environment, but (I think) code executed by the multiverse looks for its variables in the global environment? (is that right?). This is why your `test_df`s aren't found when executed by testthat, but are found if you happened to define them in advance in the global environment.

There's a bigger potential issue here of just what should the parent environment to the multiverse environments *be* (maybe where the multiverse is first created, if that's possible?). Should to open an issue to keep track of that question.

In the meantime, the hackish solution is to just use `<<-` to write the `test_df`s into the global environment when running tests, and we can revisit later if we decide to change the parent environment for the universe environments.
